### PR TITLE
index change event

### DIFF
--- a/docs/components/droplist.md
+++ b/docs/components/droplist.md
@@ -7,6 +7,7 @@ Event Name | Description
 (Refer to `Drop` component) | DropList components also emit all events by Drop components
 `@insert` | Triggered when data is to be inserted into the list (properties : `type`, `data` and `index`). If no listener is provided for this event, the list cannot be inserted into.
 `@reorder` | Triggers when data needs to be reordered (properties : `from`, `to` and `apply` - apply is a function that applies the required reordering to the given array). If no listener is provided for this event, the list cannot be reordered.
+`@closest-index-change` | Triggers as list telegraphs drop positions to the user as they drag over list items, but before the drop is made (properties : `priorIndex`, `currentIndex`) and before insert or reorder are called.  Useful for triggering sounds/animations as user drags item over list items.
 
 ## Props
 Prop Name | Type / Default | Description

--- a/lib/src/components/DropList.vue
+++ b/lib/src/components/DropList.vue
@@ -3,7 +3,7 @@ import { TransitionGroup, h } from 'vue';
 import DropMixin, { dropAllowed, doDrop, candidate } from '../mixins/DropMixin';
 import DragFeedback from './DragFeedback.vue';
 import Grid from '../js/Grid';
-import { InsertEvent, ReorderEvent } from '../js/events';
+import { InsertEvent, ReorderEvent, IndexChangeEvent } from '../js/events';
 import { createDragImage } from '../js/createDragImage';
 import { dnd } from '../js/DnD';
 
@@ -36,7 +36,7 @@ export default {
       default: undefined
     }
   },
-  emits: ['reorder', 'insert'],
+  emits: ['reorder', 'insert', 'closest-index-change'],
   data () {
     return {
       grid: null,
@@ -44,6 +44,11 @@ export default {
       feedbackKey: null,
       fromIndex: null
     };
+  },
+  watch:{
+    closestIndex (newVal, oldVal){
+      this.$emit('closest-index-change', new IndexChangeEvent (oldVal,newVal));
+    },
   },
   computed: {
     rootTag () {

--- a/lib/src/js/events.js
+++ b/lib/src/js/events.js
@@ -37,3 +37,13 @@ export class InsertEvent {
       this.index = index;
     }
 }
+
+export class IndexChangeEvent {
+  priorIndex;
+  currentIndex;
+  
+  constructor (priorIndex, currentIndex) {
+    this.priorIndex   = priorIndex;
+    this.currentIndex = currentIndex;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
     },
     "lib": {
       "name": "vue-easy-dnd",
-      "version": "2.1.0",
+      "version": "2.1.3",
       "license": "MIT",
       "dependencies": {
         "mitt": "^3.0.0",

--- a/src/App2.vue
+++ b/src/App2.vue
@@ -14,13 +14,17 @@
           </drag>
         </div>
       </div>
+      
       <div class="col">
         <drop-list
+          ref="dropit"
           :items="items"
           accepts-type="test"
           class="list"
           @insert="onInsert"
           @reorder="$event.apply(items)"
+          @closest-index-change="onClosestIndexChange"
+          @dragover="onDragover"
         >
           <template #item="{item, reorder}">
             <drag
@@ -40,11 +44,18 @@
           </template>
         </drop-list>
       </div>
+
       <drop
         class="col"
         style="background-color: grey"
         mode="cut"
       />
+    </div>
+    <div class='indexes'>
+      <small>
+        Previous Index: {{ prevIndex }}
+        Current Index: {{ newIndex }}
+      </small>
     </div>
   </Page>
 </template>
@@ -61,6 +72,8 @@ export default {
   components: { Page, Drop, Drag, DropList },
   data () {
     return {
+      prevIndex : null,
+      newIndex : null,
       items: ['a', 'b', 'c', 'd', 'e']
     };
   },
@@ -68,6 +81,12 @@ export default {
     onInsert (event) {
       console.log('on insert');
       this.items.splice(event.index, 0, event.data);
+    },
+    onClosestIndexChange (event){
+      console.log(event);
+    },
+    onDragover (event) {
+      console.log(event);
     }
   }
 };
@@ -116,6 +135,9 @@ export default {
                     transform: translate(-50%, -50%);
                 }
             }
+        }
+        .indexes{
+          text-align: center;
         }
     }
 </style>


### PR DESCRIPTION
Adds a "closest-index-change" event to the DropList, to telegraph when user has dragged an item over another index in the DropList.  Useful for triggering sounds/animations on list items.